### PR TITLE
Some fixes, unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+php:
+  # aliased to 5.3.29
+  - 5.3
+  # aliased to a recent 5.4.x version
+  - 5.4
+  # aliased to a recent 5.5.x version
+  - 5.5
+  # aliased to a recent 5.6.x version
+  - 5.6
+script: phpunit --configuration phpunit.xml.dist --coverage-text

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 IPTools
 =======
 
+[![Build Status](https://travis-ci.org/andrius-kulbis/IPTools.svg)](https://travis-ci.org/andrius-kulbis/IPTools)
+
 IP Operations
 -------------
 ```php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
          bootstrap="./tests/bootstrap.php"
         >
     <testsuites>
-        <testsuite name="PHP-IPAddress Test Suite">
+        <testsuite name="IPTools Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="./tests/bootstrap.php"
+        >
+    <testsuites>
+        <testsuite name="PHP-IPAddress Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory>./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/IP.php
+++ b/src/IP.php
@@ -84,12 +84,14 @@ class IP
 	 */
 	public static function parse($ip)
 	{
-		if (is_numeric($ip)) {
-			return self::parseLong($ip);
-		} elseif (strpos($ip, '0b') === 0) {
-			return self::parseBin($ip);
-		} elseif (strpos($ip, '0x') === 0) {
+		if (strpos($ip, '0x') === 0) {
+			$ip = substr($ip, 2);
 			return self::parseHex($ip);
+		} elseif (strpos($ip, '0b') === 0) {
+			$ip = substr($ip, 2);
+			return self::parseBin($ip);
+		} else if (is_numeric($ip)) {
+			return self::parseLong($ip);
 		}
 
 		return new self($ip);

--- a/src/Network.php
+++ b/src/Network.php
@@ -109,7 +109,7 @@ class Network implements \Iterator, \Countable
 			: IP::IP_V6_MAX_PREFIX_LENGTH; 
 
 		if (!is_numeric($prefixLength)
-			&& !($prefixLength >= 0 && $prefixLength <= $maxPrefixLength)
+			|| !($prefixLength >= 0 && $prefixLength <= $maxPrefixLength)
 		) {
 			throw new \Exception('Invalid prefix length');
 		}

--- a/tests/IPTest.php
+++ b/tests/IPTest.php
@@ -43,6 +43,16 @@ class IPTest extends \PHPUnit_Framework_TestCase
 
     }
 
+
+    /**
+     * @dataProvider getTestParseData
+     */
+    public function testParse($ipString, $expected)
+    {
+        $ip = IP::parse($ipString);
+        $this->assertEquals($expected, (string) $ip);
+    }
+
     /**
      * @dataProvider getParseBinData
      */
@@ -129,6 +139,18 @@ class IPTest extends \PHPUnit_Framework_TestCase
             array('2001::', '2001::'),
             array('2001:0000:0000:0000:0000:0000:0000:0000', '2001::'),
             array('2001:0000:0000:0000:8000:0000:0000:0000', '2001::8000:0:0:0')
+        );
+    }
+
+    public function getTestParseData()
+    {
+        return array(
+            array(2130706433, '127.0.0.1'), //long
+            array('0b01111111000000000000000000000001', '127.0.0.1'), //bin
+            array('0x7f000001', '127.0.0.1'), //hex,
+            array('0x20010000000000008000000000000000', '2001::8000:0:0:0'), //hex
+            array('127.0.0.1', '127.0.0.1'),
+            array('2001::', '2001::')
         );
     }
 

--- a/tests/NetworkTest.php
+++ b/tests/NetworkTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use IPTools\Network;
+use IPTools\IP;
+
+class NetworkTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getPrefixData
+     */
+    public function testPrefix2Mask($prefix, $version, $mask)
+    {
+        $this->assertEquals($mask, Network::prefix2netmask($prefix, $version));
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage Wrong IP version
+     */
+    public function testPrefix2MaskWrongIPVersion()
+    {
+        Network::prefix2netmask('128', 'ip_version');
+    }
+
+    /**
+     * @dataProvider getInvalidPrefixData
+     * @expectedException Exception
+     * @expectedExceptionMessage Invalid prefix length
+     */
+    public function testPrefix2MaskInvalidPrefix($prefix, $version)
+    {
+        Network::prefix2netmask($prefix, $version);
+    }
+
+    public function getPrefixData()
+    {
+        return array(
+            array('24', IP::IP_V4, IP::parse('255.255.255.0')),
+            array('32', IP::IP_V4, IP::parse('255.255.255.255')),
+            array('64', IP::IP_V6, IP::parse('ffff:ffff:ffff:ffff::')),
+            array('128', IP::IP_V6, IP::parse('ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff'))
+        );
+    }
+
+    public function getInvalidPrefixData()
+    {
+        return array(
+            array('-1', IP::IP_V4),
+            array('33', IP::IP_V4),
+            array('prefix', IP::IP_V4),
+            array('-1', IP::IP_V6),
+            array('129', IP::IP_V6),
+        );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+
+require __DIR__ . '/../src/IP.php';
+require __DIR__ . '/../src/Network.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,3 +2,4 @@
 
 require __DIR__ . '/../src/IP.php';
 require __DIR__ . '/../src/Network.php';
+require __DIR__ . '/../src/Range.php';


### PR DESCRIPTION
*Network::prefix2mask():* ```OR``` instead of  ```AND``` should be used to correctly validate the prefix.
*IP::parse():* remove bin/hex suffix before parsing