### PR TITLE
bug-fix: use binary-safe function strcmp to compare 2 ip inaddr.

### DIFF
--- a/src/Network.php
+++ b/src/Network.php
@@ -282,8 +282,8 @@ class Network implements \Iterator, \Countable
 	{
 		$exclude = self::parse($exclude);
 
-		if($exclude->getFirstIP()->inAddr() > $this->getLastIP()->inAddr()
-			|| $exclude->getLastIP()->inAddr() < $this->getFirstIP()->inAddr()
+		if( strcmp($exclude->getFirstIP()->inAddr() , $this->getLastIP()->inAddr()) > 0
+			|| strcmp($exclude->getLastIP()->inAddr() , $this->getFirstIP()->inAddr()) < 0
 		) {
 			throw new \Exception('Exclude subnet not within target network');
 		}
@@ -408,7 +408,7 @@ class Network implements \Iterator, \Countable
 	*/
 	public function valid()
 	{
-		return $this->getFirstHost()->next($this->position)->inAddr() <= $this->getLastHost()->inAddr();
+		return strcmp($this->getFirstHost()->next($this->position)->inAddr() , $this->getLastHost()->inAddr()) <= 0;
 	}
 
 	/**

--- a/src/Range.php
+++ b/src/Range.php
@@ -66,14 +66,14 @@ class Range implements \Iterator, \Countable
 	public function contains($find)
 	{
 		if($find instanceof IP) {
-			$within = ($find->inAddr() >= $this->firstIP->inAddr())
-				&& ($find->inAddr() <= $this->lastIP->inAddr());
+			$within = (strcmp($find->inAddr() , $this->firstIP->inAddr()) >= 0)
+				&& (strcmp($find->inAddr() , $this->lastIP->inAddr()) <= 0);
 		} elseif($find instanceof Range || $find instanceof Network) {
 			/**
 			 * @var Network|Range $find
 			 */
-			$within = ($find->getFirstIP()->inAddr() >= $this->firstIP->inAddr())
-				&& ($find->getLastIP()->inAddr() <= $this->lastIP->inAddr());
+			$within = (strcmp($find->getFirstIP()->inAddr() , $this->firstIP->inAddr()) >= 0)
+				&& (strcmp($find->getLastIP()->inAddr() , $this->lastIP->inAddr()) <= 0);
 		} else {
 			throw new \Exception('Invalid type');
 		}
@@ -87,7 +87,7 @@ class Range implements \Iterator, \Countable
 	 */
 	public function setFirstIP(IP $ip)
 	{
-		if($this->lastIP && $ip->inAddr() > $this->lastIP->inAddr()) {
+		if($this->lastIP && strcmp($ip->inAddr() , $this->lastIP->inAddr()) > 0) {
 			throw new \Exception('First IP is grater than second');
 		}
 
@@ -100,7 +100,7 @@ class Range implements \Iterator, \Countable
 	 */
 	public function setLastIP(IP $ip)
 	{
-		if($this->firstIP && $ip->inAddr() < $this->firstIP->inAddr()) {
+		if($this->firstIP && strcmp($ip->inAddr() , $this->firstIP->inAddr()) < 0) {
 			throw new \Exception('Last IP is less than first');
 		}
 
@@ -144,7 +144,7 @@ class Range implements \Iterator, \Countable
 				 * @var Network $network
 				 */
 				foreach ($excluded as $network) {
-					if($network->getFirstIP()->inAddr() >= $this->firstIP->inAddr()) {
+					if(strcmp($network->getFirstIP()->inAddr() , $this->firstIP->inAddr()) >=0) {
 						$networks[] = $network;
 					}
 				}
@@ -218,7 +218,7 @@ class Range implements \Iterator, \Countable
 	 */
 	public function valid()
 	{
-		return $this->firstIP->next($this->position)->inAddr() <= $this->lastIP->next($this->position)->inAddr();
+		return strcmp($this->firstIP->next($this->position)->inAddr() , $this->lastIP->next($this->position)->inAddr() <=0);
 	}
 
 	/**

--- a/tests/RangeTest.php
+++ b/tests/RangeTest.php
@@ -75,6 +75,13 @@ class RangeTest extends \PHPUnit_Framework_TestCase
         return array(
             array('192.168.*.*', '192.168.245.15', true),
             array('192.168.*.*', '192.169.255.255', false),
+
+            /**
+             * 10.10.45.48 --> 00001010 00001010 00101101 00110000 
+             * the last 0000 leads error
+             */
+            array('10.10.45.48/28', '10.10.45.58', true),
+
             array('2001:db8::/64', '2001:db8::ffff', true),
             array('2001:db8::/64', '2001:db8:ffff::', false),
         );


### PR DESCRIPTION
found a contains error occur.
because operator < > <= >=  is not binary-safe, so i use strcmp to compare ip inaddr. 

add a range contains test. 