### PR TITLE
Throw exception if network has invalid data at end of string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
 before_script:
  - wget http://getcomposer.org/composer.phar
  - php composer.phar install --dev --no-interaction
+ - apt-get install -y php-token-stream
 
 script:
  - mkdir -p build/logs

--- a/src/Network.php
+++ b/src/Network.php
@@ -47,10 +47,9 @@ class Network implements \Iterator, \Countable
 	 */
 	public static function parse($data)
 	{
-		if (strpos($data,'/')) {
-			list($ip, $prefixLength) = explode('/', $data, 2);
-			$ip      = IP::parse($ip);
-			$netmask = self::prefix2netmask((int)$prefixLength, $ip->getVersion());
+		if (preg_match('~^(.+?)/(\d+)$~', $data, $matches)) {
+			$ip      = IP::parse($matches[1]);
+			$netmask = self::prefix2netmask((int)$matches[2], $ip->getVersion());
 		} elseif (strpos($data,' ')) {
 			list($ip, $netmask) = explode(' ', $data, 2);
 			$ip      = IP::parse($ip);

--- a/tests/NetworkTest.php
+++ b/tests/NetworkTest.php
@@ -42,6 +42,15 @@ class NetworkTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException Exception
+     * @expectedExceptionMessage Invalid IP address format
+     */
+    public function testParseWrongNetwork()
+    {
+        Network::parse('10.0.0.0/24 abc');
+    }
+
+    /**
      * @dataProvider getPrefixData
      */
     public function testPrefix2Mask($prefix, $version, $mask)

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once 'PHP/Token/Stream/Autoload.php';
 require __DIR__ . '/../src/PropertyTrait.php';
 require __DIR__ . '/../src/IP.php';
 require __DIR__ . '/../src/Network.php';


### PR DESCRIPTION
String `10.0.0.0/24 abc` was parsed as a valid Network, this patches fixes that issue.