### PR TITLE
Fix for S1lentium/IPTools#15

### DIFF
--- a/src/Network.php
+++ b/src/Network.php
@@ -352,11 +352,11 @@ class Network implements \Iterator, \Countable
 	}
 
 	/**
-	* @return int
+	* @return int|string
 	*/
 	public function count()
 	{
-		return (integer)$this->getBlockSize();
+		return $this->getBlockSize();
 	}
 
 }

--- a/src/Range.php
+++ b/src/Range.php
@@ -222,11 +222,11 @@ class Range implements \Iterator, \Countable
 	}
 
 	/**
-	 * @return int
+	 * @return string
 	 */
 	public function count()
 	{
-		return (integer)bcadd(bcsub($this->lastIP->toLong(), $this->firstIP->toLong()), 1);
+		return (string)bcadd(bcsub($this->lastIP->toLong(), $this->firstIP->toLong()), 1);
 	}
 
 }

--- a/tests/NetworkTest.php
+++ b/tests/NetworkTest.php
@@ -153,7 +153,8 @@ class NetworkTest extends \PHPUnit_Framework_TestCase
      */
     public function testCount($data, $expected)
     {
-        $this->assertEquals($expected, count(Network::parse($data)));
+        $this->assertEquals($expected, Network::parse($data)->count());
+        # $this->assertEquals($expected, count(Network::parse($data)));
     }
 
     public function getTestParseData()
@@ -290,6 +291,7 @@ class NetworkTest extends \PHPUnit_Framework_TestCase
         return array(
             array('127.0.0.0/31', 2),
             array('2001:db8::/120', 256),
+            array('::/0', 340282366920938463463374607431768211456),
         );
     }
 }

--- a/tests/RangeTest.php
+++ b/tests/RangeTest.php
@@ -56,7 +56,8 @@ class RangeTest extends \PHPUnit_Framework_TestCase
      */
     public function testCount($data, $expected)
     {
-        $this->assertEquals($expected, count(Range::parse($data)));
+        $this->assertEquals($expected, Range::parse($data)->count());
+        # $this->assertEquals($expected, count(Range::parse($data)));
     }
 
     public function getTestParseData()
@@ -140,6 +141,7 @@ class RangeTest extends \PHPUnit_Framework_TestCase
         return array(
             array('127.0.0.0/31', 2),
             array('2001:db8::/120', 256),
+            array('::/0', 340282366920938463463374607431768211456),
         );
     }
 


### PR DESCRIPTION
IPv6 blocksize can exceed the maximum number for integer (2^32 or 2^64).

This commit fixes `$network->count()` [1] (by returning the number of hosts as a string if it exceeds the max integer size). It can't fix `count($network)` [2], since PHP's `count()` must return an integer.

[1] Or `$range->count()`
[2] Or `count($range)