### PR TITLE
Network::containsIP(IP)

### DIFF
--- a/src/Network.php
+++ b/src/Network.php
@@ -137,6 +137,15 @@ class Network implements \Iterator, \Countable
 	}
 
 	/**
+	 * @param IP ip
+	 * @return bool
+	 */
+	public function containsIP(IP $ip)
+	{
+		return Range::parse($this->getFirstIP() . '-' . $this->getLastIP())->contains($ip);
+	}
+
+	/**
 	 * @return IP
 	 */
 	public function getIP()

--- a/tests/NetworkTest.php
+++ b/tests/NetworkTest.php
@@ -31,6 +31,8 @@ class NetworkTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('0.0.0.255', (string)$network->wildcard);
         $this->assertEquals('192.0.0.0', (string)$network->firstIP);
         $this->assertEquals('192.0.0.255', (string)$network->lastIP);
+        $this->assertEquals(true, $network->containsIP(new IP('192.0.0.5')));
+        $this->assertEquals(false, $network->containsIP(new IP('192.0.1.2')));
     }
 
     /**


### PR DESCRIPTION
The `contains(IP)` is a function of the **_Range_** class only, so I 've added something similar in **_Network_** by utilizing existing functions. cheers.