### PR TITLE
Add phpunit/phpunit as dev-dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "ext-bcmath": "*"
     },
     "require-dev": {
-        "satooshi/php-coveralls": "~1.0"
+        "satooshi/php-coveralls": "~1.0",
+        "phpunit/phpunit": "~4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I wasn't able to run tests locally without that ... you shouldn't rely on a globally installed "binary"