### PR TITLE
Introduce custom exceptions so they can be caught

### DIFF
--- a/src/Exception/IpException.php
+++ b/src/Exception/IpException.php
@@ -1,0 +1,8 @@
+<?php
+namespace IPTools\Exception;
+
+use Exception;
+
+final class IpException extends Exception implements IpToolsException
+{
+}

--- a/src/Exception/IpToolsException.php
+++ b/src/Exception/IpToolsException.php
@@ -1,0 +1,6 @@
+<?php
+namespace IPTools\Exception;
+
+interface IpToolsException
+{
+}

--- a/src/Exception/NetworkException.php
+++ b/src/Exception/NetworkException.php
@@ -1,0 +1,8 @@
+<?php
+namespace IPTools\Exception;
+
+use Exception;
+
+final class NetworkException extends Exception implements IpToolsException
+{
+}

--- a/src/Exception/RangeException.php
+++ b/src/Exception/RangeException.php
@@ -1,0 +1,8 @@
+<?php
+namespace IPTools\Exception;
+
+use Exception;
+
+final class RangeException extends Exception implements IpToolsException
+{
+}

--- a/src/IP.php
+++ b/src/IP.php
@@ -1,6 +1,8 @@
 <?php
 namespace IPTools;
 
+use IPTools\Exception\IpException;
+
 /**
  * @author Safarov Alisher <alisher.safarov@outlook.com>
  * @link https://github.com/S1lentium/IPTools
@@ -25,12 +27,12 @@ class IP
 
 	/**
 	 * @param string ip
-	 * @throws \Exception
+	 * @throws IpException
 	 */
 	public function __construct($ip)
 	{
 		if (!filter_var($ip, FILTER_VALIDATE_IP)) {
-			throw new \Exception("Invalid IP address format");
+			throw new IpException("Invalid IP address format");
 		}
 		$this->in_addr = inet_pton($ip);
 	}
@@ -68,13 +70,13 @@ class IP
 
 	/**
 	 * @param string $binIP
-	 * @throws \Exception
+	 * @throws IpException
 	 * @return IP
 	 */
 	public static function parseBin($binIP)
 	{
 		if (!preg_match('/^([0-1]{32}|[0-1]{128})$/', $binIP)) {
-			throw new \Exception("Invalid binary IP address format");
+			throw new IpException("Invalid binary IP address format");
 		}
 
 		$in_addr = '';
@@ -87,13 +89,13 @@ class IP
 
 	/**
 	 * @param string $hexIP
-	 * @throws \Exception
+	 * @throws IpException
 	 * @return IP
 	 */
 	public static function parseHex($hexIP)
 	{
 		if (!preg_match('/^([0-9a-fA-F]{8}|[0-9a-fA-F]{32})$/', $hexIP)) {
-			throw new \Exception("Invalid hexadecimal IP address format");
+			throw new IpException("Invalid hexadecimal IP address format");
 		}
 
 		return new self(inet_ntop(pack('H*', $hexIP)));
@@ -231,12 +233,12 @@ class IP
 	/**
 	 * @param int $to
 	 * @return IP
-	 * @throws \Exception
+	 * @throws IpException
 	 */
 	public function next($to=1)
 	{
 		if ($to < 0) {
-			throw new \Exception("Number must be greater than 0");
+			throw new IpException("Number must be greater than 0");
 		}
 
 		$unpacked = unpack('C*', $this->in_addr);
@@ -258,13 +260,13 @@ class IP
 	/**
 	 * @param int $to
 	 * @return IP
-	 * @throws \Exception
+	 * @throws IpException
 	 */
 	public function prev($to=1)
 	{
 
 		if ($to < 0) {
-			throw new \Exception("Number must be greater than 0");
+			throw new IpException("Number must be greater than 0");
 		}
 
 		$unpacked = unpack('C*', $this->in_addr);

--- a/src/Network.php
+++ b/src/Network.php
@@ -1,6 +1,7 @@
 <?php
 namespace IPTools;
 
+use IPTools\Exception\NetworkException;
 use ReturnTypeWillChange;
 
 /**
@@ -68,12 +69,12 @@ class Network implements \Iterator, \Countable
 	 * @param int $prefixLength
 	 * @param string $version
 	 * @return IP
-	 * @throws \Exception
+	 * @throws NetworkException
 	 */
 	public static function prefix2netmask($prefixLength, $version)
 	{
 		if (!in_array($version, array(IP::IP_V4, IP::IP_V6))) {
-			throw new \Exception("Wrong IP version");
+			throw new NetworkException("Wrong IP version");
 		}
 
 		$maxPrefixLength = $version === IP::IP_V4
@@ -83,7 +84,7 @@ class Network implements \Iterator, \Countable
 		if (!is_numeric($prefixLength)
 			|| !($prefixLength >= 0 && $prefixLength <= $maxPrefixLength)
 		) {
-			throw new \Exception('Invalid prefix length');
+			throw new NetworkException('Invalid prefix length');
 		}
 
 		$binIP = str_pad(str_pad('', (int)$prefixLength, '1'), $maxPrefixLength, '0');
@@ -102,12 +103,12 @@ class Network implements \Iterator, \Countable
 
 	/**
 	 * @param IP ip
-	 * @throws \Exception
+	 * @throws NetworkException
 	 */
 	public function setIP(IP $ip)
 	{
 		if (isset($this->netmask) && $this->netmask->getVersion() !== $ip->getVersion()) {
-			throw new \Exception('IP version is not same as Netmask version');
+			throw new NetworkException('IP version is not same as Netmask version');
 		}
 
 		$this->ip = $ip;
@@ -115,16 +116,16 @@ class Network implements \Iterator, \Countable
 
 	/**
 	 * @param IP ip
-	 * @throws \Exception
+	 * @throws NetworkException
 	 */
 	public function setNetmask(IP $ip)
 	{
 		if (!preg_match('/^1*0*$/',$ip->toBin())) {
-			throw new \Exception('Invalid Netmask address format');
+			throw new NetworkException('Invalid Netmask address format');
 		}
 
 		if (isset($this->ip) && $ip->getVersion() !== $this->ip->getVersion()) {
-			throw new \Exception('Netmask version is not same as IP version');
+			throw new NetworkException('Netmask version is not same as IP version');
 		}
 
 		$this->netmask = $ip;
@@ -246,7 +247,7 @@ class Network implements \Iterator, \Countable
 	/**
 	 * @param IP|Network $exclude
 	 * @return Network[]
-	 * @throws \Exception
+	 * @throws NetworkException
 	 */
 	public function exclude($exclude)
 	{
@@ -255,7 +256,7 @@ class Network implements \Iterator, \Countable
 		if (strcmp($exclude->getFirstIP()->inAddr() , $this->getLastIP()->inAddr()) > 0
 			|| strcmp($exclude->getLastIP()->inAddr() , $this->getFirstIP()->inAddr()) < 0
 		) {
-			throw new \Exception('Exclude subnet not within target network');
+			throw new NetworkException('Exclude subnet not within target network');
 		}
 
 		$networks = array();
@@ -298,14 +299,14 @@ class Network implements \Iterator, \Countable
 	/**
 	 * @param int $prefixLength
 	 * @return Network[]
-	 * @throws \Exception
+	 * @throws NetworkException
 	 */
 	public function moveTo($prefixLength)
 	{
 		$maxPrefixLength = $this->ip->getMaxPrefixLength();
 
 		if ($prefixLength <= $this->getPrefixLength() || $prefixLength > $maxPrefixLength) {
-			throw new \Exception('Invalid prefix length ');
+			throw new NetworkException('Invalid prefix length ');
 		}
 
 		$netmask = self::prefix2netmask($prefixLength, $this->ip->getVersion());

--- a/src/Range.php
+++ b/src/Range.php
@@ -1,6 +1,7 @@
 <?php
 namespace IPTools;
 
+use IPTools\Exception\RangeException;
 use ReturnTypeWillChange;
 
 /**
@@ -27,7 +28,7 @@ class Range implements \Iterator, \Countable
 	/**
 	 * @param IP $firstIP
 	 * @param IP $lastIP
-	 * @throws \Exception
+	 * @throws RangeException
 	 */
 	public function __construct(IP $firstIP, IP $lastIP)
 	{
@@ -63,7 +64,7 @@ class Range implements \Iterator, \Countable
 	/**
 	 * @param IP|Network|Range $find
 	 * @return bool
-	 * @throws \Exception
+	 * @throws RangeException
 	 */
 	public function contains($find)
 	{
@@ -77,7 +78,7 @@ class Range implements \Iterator, \Countable
 			$within = (strcmp($find->getFirstIP()->inAddr(), $this->firstIP->inAddr()) >= 0)
 				&& (strcmp($find->getLastIP()->inAddr(), $this->lastIP->inAddr()) <= 0);
 		} else {
-			throw new \Exception('Invalid type');
+			throw new RangeException('Invalid type');
 		}
 
 		return $within;
@@ -85,12 +86,12 @@ class Range implements \Iterator, \Countable
 
 	/**
 	 * @param IP $ip
-	 * @throws \Exception
+	 * @throws RangeException
 	 */
 	public function setFirstIP(IP $ip)
 	{
 		if ($this->lastIP && strcmp($ip->inAddr(), $this->lastIP->inAddr()) > 0) {
-			throw new \Exception('First IP is grater than second');
+			throw new RangeException('First IP is grater than second');
 		}
 
 		$this->firstIP = $ip;
@@ -98,12 +99,12 @@ class Range implements \Iterator, \Countable
 
 	/**
 	 * @param IP $ip
-	 * @throws \Exception
+	 * @throws RangeException
 	 */
 	public function setLastIP(IP $ip)
 	{
 		if ($this->firstIP && strcmp($ip->inAddr(), $this->firstIP->inAddr()) < 0) {
-			throw new \Exception('Last IP is less than first');
+			throw new RangeException('Last IP is less than first');
 		}
 
 		$this->lastIP = $ip;


### PR DESCRIPTION
There's no way to properly catch exceptions from this lib. This fixes it so concrete exceptions can be caught or `IpToolsException` can be caught to catch everything from the lib.

Resolves https://github.com/S1lentium/IPTools/issues/21