### PR TITLE
fix: replace non-canonical (integer) cast deprecated in PHP 8.5

### DIFF
--- a/src/Network.php
+++ b/src/Network.php
@@ -374,7 +374,7 @@ class Network implements \Iterator, \Countable
 	#[ReturnTypeWillChange]
 	public function count()
 	{
-		return (integer)$this->getBlockSize();
+		return (int)$this->getBlockSize();
 	}
 
 }

--- a/src/Range.php
+++ b/src/Range.php
@@ -237,7 +237,7 @@ class Range implements \Iterator, \Countable
 	#[ReturnTypeWillChange]
 	public function count()
 	{
-		return (integer)bcadd(bcsub($this->lastIP->toLong(), $this->firstIP->toLong()), 1);
+		return (int)bcadd(bcsub($this->lastIP->toLong(), $this->firstIP->toLong()), 1);
 	}
 
 }


### PR DESCRIPTION
PHP 8.5+ deprecates non-canonical type cast aliases `(integer)`, `(boolean)`, `(double)` and `(binary)`. Using these aliases produces a deprecation notice on PHP 8.5+ which will become a fatal error in a future PHP version.


## Steps to reproduce
1. Run tests on PHP 8.5:
   vendor/bin/phpunit --display-deprecations

2. You will see:
   Non-canonical cast (integer) is deprecated, use the (int) cast instead
   - src/Network.php:377
   - src/Range.php:240

## Solution
Replace with canonical alias:
(integer) → (int)

## References
1. https://php.watch/versions/8.5/boolean-double-integer-binary-casts-deprecated
2. https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_non-standard_cast_names

## Note on maintainability
Meanwhile, a compatible fork is available at: https://packagist.org/packages/wombatbuddy/iptools